### PR TITLE
[iter24]: Add HTTPS support and conditional pprof routes based on env…

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -174,8 +174,8 @@ func (a *App) SetupRoutes() {
 // Run запускает HTTP-сервер приложения на адресе, указанном в настройках.
 // Возвращает ошибку, если сервер не может быть запущен.
 func (a *App) Run() error {
-	enableHttps := a.settings.IsHttpsEnabled()
-	if enableHttps {
+	enableHTTPS := a.settings.IsHTTPSEnabled()
+	if enableHTTPS {
 		a.logger.Infof("Starting HTTPS server at %s", a.settings.GetServerAddress())
 		err := http.ListenAndServeTLS(a.settings.GetServerAddress(), "cert.pem", "key.pem", a.router)
 		if err != nil {

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -53,7 +53,7 @@ func NewFlags() *Flags {
 		"полный URL удаленного сервера-приёмника, куда отправляются логи аудита",
 	)
 
-	enableHttps := flag.Bool(
+	enableHTTPS := flag.Bool(
 		"s",
 		false,
 		"",
@@ -67,6 +67,6 @@ func NewFlags() *Flags {
 		DatabaseDSN:     *databaseDSN,
 		AuditFile:       *auditFile,
 		AuditURL:        *auditURL,
-		EnableHTTPS:     *enableHttps,
+		EnableHTTPS:     *enableHTTPS,
 	}
 }

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -11,6 +11,7 @@ type Flags struct {
 	DatabaseDSN     string
 	AuditFile       string
 	AuditURL        string
+	EnableHTTPS     bool
 }
 
 // NewFlags создает новый экземпляр флагов командной строки.
@@ -52,6 +53,11 @@ func NewFlags() *Flags {
 		"полный URL удаленного сервера-приёмника, куда отправляются логи аудита",
 	)
 
+	enableHttps := flag.Bool(
+		"s",
+		false,
+		"",
+	)
 	flag.Parse()
 
 	return &Flags{
@@ -61,5 +67,6 @@ func NewFlags() *Flags {
 		DatabaseDSN:     *databaseDSN,
 		AuditFile:       *auditFile,
 		AuditURL:        *auditURL,
+		EnableHTTPS:     *enableHttps,
 	}
 }

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -4,6 +4,7 @@ const (
 	defaultServerHost = "localhost"
 	defaultServerPort = 8080
 	defaultBaseURL    = "http://localhost:8080/"
+	defaultHttpsUsage = true
 )
 
 // ServerSettings содержит настройки HTTP-сервера.
@@ -15,4 +16,11 @@ type ServerSettings struct {
 	ServerDomain  string `envconfig:"SERVER_DOMAIN" default:"localhost" required:"true"`
 	BaseURL       string `envconfig:"BASE_URL" default:"" required:"false"`
 	Environment   string `envconfig:"ENVIRONMENT" default:"development" required:"false"`
+	EnableHTTPS   bool   `envconfig:"ENABLE_HTTPS" default:"false"`
+}
+
+// IsProd возвращает true, если текущее окружение является производственным (production).
+// Проверяет значение поля Environment на "production" или "prod".
+func (s *ServerSettings) IsProd() bool {
+	return s.Environment == "production" || s.Environment == "prod"
 }

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -4,7 +4,7 @@ const (
 	defaultServerHost = "localhost"
 	defaultServerPort = 8080
 	defaultBaseURL    = "http://localhost:8080/"
-	defaultHttpsUsage = false
+	defaultHTTPSUsage = false
 )
 
 // ServerSettings содержит настройки HTTP-сервера.

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -4,7 +4,7 @@ const (
 	defaultServerHost = "localhost"
 	defaultServerPort = 8080
 	defaultBaseURL    = "http://localhost:8080/"
-	defaultHttpsUsage = true
+	defaultHttpsUsage = false
 )
 
 // ServerSettings содержит настройки HTTP-сервера.

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -165,18 +165,18 @@ func (s *Settings) GetAuditURL() string {
 	return defaultAuditURL
 }
 
-// IsHttpsEnabled возвращает true, если HTTPS включен в настройках.
-func (s *Settings) IsHttpsEnabled() bool {
+// IsHTTPSEnabled возвращает true, если HTTPS включен в настройках.
+func (s *Settings) IsHTTPSEnabled() bool {
 	// Если указана переменная окружения, то используется она
-	if enableHttps := s.EnvSettings.Server.EnableHTTPS; enableHttps {
-		return enableHttps
+	if enableHTTPS := s.EnvSettings.Server.EnableHTTPS; enableHTTPS {
+		return enableHTTPS
 	}
 
 	// Если нет переменной окружения, но есть аргумент командной строки(флаг), то используется он
-	if enableHttps := s.Flags.EnableHTTPS; enableHttps {
-		return enableHttps
+	if enableHTTPS := s.Flags.EnableHTTPS; enableHTTPS {
+		return enableHTTPS
 	}
 
 	// Если параметр не передан, то не используем параметр по умолчанию.
-	return defaultHttpsUsage
+	return defaultHTTPSUsage
 }

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -164,3 +164,19 @@ func (s *Settings) GetAuditURL() string {
 	// Если параметр не передан, аудит на удалённый сервер должен быть отключён.
 	return defaultAuditURL
 }
+
+// IsHttpsEnabled возвращает true, если HTTPS включен в настройках.
+func (s *Settings) IsHttpsEnabled() bool {
+	// Если указана переменная окружения, то используется она
+	if enableHttps := s.EnvSettings.Server.EnableHTTPS; enableHttps {
+		return enableHttps
+	}
+
+	// Если нет переменной окружения, но есть аргумент командной строки(флаг), то используется он
+	if enableHttps := s.Flags.EnableHTTPS; enableHttps {
+		return enableHttps
+	}
+
+	// Если параметр не передан, то не используем параметр по умолчанию.
+	return defaultHttpsUsage
+}


### PR DESCRIPTION
### Задание по треку «Сервис сокращения URL»
Добавьте в свой код возможность включения HTTPS в веб-сервере. 
При передаче флага -s или переменной окружения ENABLE_HTTPS запускайте сервер с помощью метода http.ListenAndServeTLS или tls.Listen.